### PR TITLE
【fix】#120 レストランマーカー連続クリックで前のカード情報が一瞬表示される

### DIFF
--- a/frontend/src/components/features/map/map-canvas.tsx
+++ b/frontend/src/components/features/map/map-canvas.tsx
@@ -26,7 +26,10 @@ export default function MapCanvas({ midpoint, restaurants }: MapItems) {
   }, [restaurants])
 
   const handleRestaurantClick = useCallback(
-    (restaurant: RestaurantListItem) => setSelected(restaurant),
+    (restaurant: RestaurantListItem) => {
+      setMapData(prev => ({ ...prev, markerPosition: null }))
+      setSelected(restaurant)
+    },
     [],
   )
 


### PR DESCRIPTION
# 概要

Closed #120 

レストランマーカーを連続でクリックした際、新しいカードに古いレストラン情報が一瞬表示される問題を修正。

マーカークリック時に `mapData.markerPosition` をリセットすることで、位置計算が完了するまでカードを非表示にし、古い情報の表示を防止する。

### スクリーンショット

|       | Before | After |
| :---: | :----: | :---: |
| カード | ![before](https://github.com/user-attachments/assets/489e2c3f-a66d-43e4-bed1-b933aadca29b) | ![after](https://github.com/user-attachments/assets/10243491-95fa-498a-810d-0184c7712878) |

## 影響範囲・懸念点

- 地図上のレストランマーカークリック時のカード表示処理

## おこなった動作確認

<!-- おこなった動作確認を箇条書きで。大きなUI変更は iOS Safari / Android Chrome での確認もすること -->
- [x]  マーカーを連続クリックしても古い情報が表示されないこと
- [x] 通常のマーカークリックでカードが正常に表示されること
- [x] モバイル・デスクトップ両方で動作確認