### PR TITLE
【Fix】#182 vi.hoisted() / vi.unmock() の非トップレベル呼び出しを修正

### DIFF
--- a/frontend/__tests__/integration/components/features/map/map-content.test.tsx
+++ b/frontend/__tests__/integration/components/features/map/map-content.test.tsx
@@ -1,15 +1,13 @@
 import type { RestaurantListItem } from '~/types/restaurant'
 import { render } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import { setupCanvasMocks } from '__tests__/integration/helpers/canvas-mocks'
 import { server } from '__tests__/integration/setup/msw.server'
 import { http, HttpResponse } from 'msw'
 import { MapContainer } from 'react-leaflet'
 import MapContent from '~/components/features/map/map-content'
 import { useMapCoords } from '~/hooks/useMapCoords'
+import '__tests__/integration/helpers/canvas-mocks'
 import '@testing-library/jest-dom/vitest'
-
-setupCanvasMocks()
 
 window.scrollTo = vi.fn()
 

--- a/frontend/__tests__/integration/components/features/map/map-content.test.tsx
+++ b/frontend/__tests__/integration/components/features/map/map-content.test.tsx
@@ -6,7 +6,6 @@ import { http, HttpResponse } from 'msw'
 import { MapContainer } from 'react-leaflet'
 import MapContent from '~/components/features/map/map-content'
 import { useMapCoords } from '~/hooks/useMapCoords'
-import '__tests__/integration/helpers/canvas-mocks'
 import '@testing-library/jest-dom/vitest'
 
 window.scrollTo = vi.fn()

--- a/frontend/__tests__/integration/helpers/canvas-mocks.ts
+++ b/frontend/__tests__/integration/helpers/canvas-mocks.ts
@@ -1,66 +1,62 @@
-export function setupCanvasMocks() {
-  vi.hoisted(() => {
-    globalThis.URL.createObjectURL = vi.fn(() => 'mock-url')
-    globalThis.URL.revokeObjectURL = vi.fn()
+globalThis.URL.createObjectURL = vi.fn(() => 'mock-url')
+globalThis.URL.revokeObjectURL = vi.fn()
 
-    class WorkerMock {
-      url: string
-      onmessage: ((event: MessageEvent) => void) | null = null
+class WorkerMock {
+  url: string
+  onmessage: ((event: MessageEvent) => void) | null = null
 
-      constructor(url: string) {
-        this.url = url
-      }
+  constructor(url: string) {
+    this.url = url
+  }
 
-      postMessage() {}
-      terminate() {}
-      addEventListener() {}
-      removeEventListener() {}
-      dispatchEvent() { return true }
-    }
-
-    globalThis.Worker = WorkerMock as any
-
-    class ImageDataMock {
-      data: Uint8ClampedArray
-      width: number
-      height: number
-
-      constructor(width: number, height: number) {
-        this.width = width
-        this.height = height
-        this.data = new Uint8ClampedArray(width * height * 4)
-      }
-    }
-
-    globalThis.ImageData = ImageDataMock as any
-
-    HTMLCanvasElement.prototype.getContext = vi.fn(() => ({
-      canvas: {},
-      fillRect: vi.fn(),
-      clearRect: vi.fn(),
-      getImageData: vi.fn(() => ({
-        data: Array.from({ length: 4 }),
-      })),
-      putImageData: vi.fn(),
-      createImageData: vi.fn(() => []),
-      setTransform: vi.fn(),
-      drawImage: vi.fn(),
-      save: vi.fn(),
-      restore: vi.fn(),
-      beginPath: vi.fn(),
-      moveTo: vi.fn(),
-      lineTo: vi.fn(),
-      closePath: vi.fn(),
-      stroke: vi.fn(),
-      translate: vi.fn(),
-      scale: vi.fn(),
-      rotate: vi.fn(),
-      arc: vi.fn(),
-      fill: vi.fn(),
-      measureText: vi.fn(() => ({ width: 0 })),
-      transform: vi.fn(),
-      rect: vi.fn(),
-      clip: vi.fn(),
-    })) as any
-  })
+  postMessage() {}
+  terminate() {}
+  addEventListener() {}
+  removeEventListener() {}
+  dispatchEvent() { return true }
 }
+
+globalThis.Worker = WorkerMock as any
+
+class ImageDataMock {
+  data: Uint8ClampedArray
+  width: number
+  height: number
+
+  constructor(width: number, height: number) {
+    this.width = width
+    this.height = height
+    this.data = new Uint8ClampedArray(width * height * 4)
+  }
+}
+
+globalThis.ImageData = ImageDataMock as any
+
+HTMLCanvasElement.prototype.getContext = vi.fn(() => ({
+  canvas: {},
+  fillRect: vi.fn(),
+  clearRect: vi.fn(),
+  getImageData: vi.fn(() => ({
+    data: Array.from({ length: 4 }),
+  })),
+  putImageData: vi.fn(),
+  createImageData: vi.fn(() => []),
+  setTransform: vi.fn(),
+  drawImage: vi.fn(),
+  save: vi.fn(),
+  restore: vi.fn(),
+  beginPath: vi.fn(),
+  moveTo: vi.fn(),
+  lineTo: vi.fn(),
+  closePath: vi.fn(),
+  stroke: vi.fn(),
+  translate: vi.fn(),
+  scale: vi.fn(),
+  rotate: vi.fn(),
+  arc: vi.fn(),
+  fill: vi.fn(),
+  measureText: vi.fn(() => ({ width: 0 })),
+  transform: vi.fn(),
+  rect: vi.fn(),
+  clip: vi.fn(),
+})) as any

--- a/frontend/__tests__/unit/helpers/ssr-helpers.ts
+++ b/frontend/__tests__/unit/helpers/ssr-helpers.ts
@@ -33,7 +33,7 @@ export async function withReactSSRMock<T>(
     return await callback()
   }
   finally {
-    vi.unmock('react')
+    vi.doUnmock('react')
     vi.resetModules()
   }
 }

--- a/frontend/vitest.config.mts
+++ b/frontend/vitest.config.mts
@@ -65,7 +65,10 @@ export default defineConfig({
         test: {
           name: 'integration-jsdom',
           environment: 'jsdom',
-          setupFiles: ['__tests__/integration/setup/msw.server.ts'],
+          setupFiles: [
+            '__tests__/integration/setup/msw.server.ts',
+            '__tests__/integration/helpers/canvas-mocks.ts',
+          ],
           include: ['__tests__/integration/components/**/*.{test,spec}.ts?(x)'],
         },
       },


### PR DESCRIPTION
# 概要

Closes #182 

 vitest 4 への移行後の警告のうち、「将来エラー化する」と明記された 2 件を解消。

- `__tests__/integration/helpers/canvas-mocks.ts` の `vi.hoisted()` 非トップレベル警告
- `__tests__/unit/helpers/ssr-helpers.ts` の `vi.unmock("react")` 非トップレベル警告

いずれも vitest の API がモジュール先頭へホイストされる仕組みと、呼び出し位置・実行順序の食い違いに起因していた。
コードの記述位置と実際の評価順を一致させる方向で修正した。

## 細かな変更点

### 1. canvas モックを setupFiles で読み込むよう変更

- `vitest.config.mts` の `integration-jsdom` プロジェクトの `setupFiles` に `__tests__/integration/helpers/canvas-mocks.ts` を追加
- `__tests__/integration/components/features/map/map-content.test.tsx` から `canvas-mocks` の import を削除

#### 背景

- `map-content.test.tsx` は `canvas-mocks` を先頭 import することで `react-leaflet` / `maplibre-gl` の評価時に `globalThis.Worker` をモック済みにしていた
- しかし `perfectionist/sort-imports` が import を並び替えるため、保存や `lint:fix` で位置がずれてテストが壊れていた
- `eslint-disable-next-line` は import 文には届かず効かない仕様（ESLint 自身が「Unused directive」と「並び替え違反」を同時に報告)
- そのためテストファイル側で import を制御する設計をやめ、`setupFiles` で先に評価する方式に変更
### 2. react の動的アンモックを `vi.doUnmock` に変更

- `__tests__/unit/helpers/ssr-helpers.ts` の `finally` 内で `vi.unmock('react')` を `vi.doUnmock('react')` に変更

#### 背景

- `vi.unmock` はホイスト対象のため、`finally` に書いても実際はファイル評価時に1回呼ばれるだけでアンモックは機能していなかった
- 動的モックに使う `vi.doMock` の対として `vi.doUnmock` に置き換え
- 警告が解消されると同時に、`try/finally` の意図通り、スコープ抜け時にアンモックする挙動が初めて正しく動くようになる

- `vitest.config.mts` の `integration-jsdom` プロジェクトに含まれる全テスト（`__tests__/integration/components/**`）で `globalThis.Worker` などのモックが常に適用されるようになる。挙動上の影響はないが、適用範囲が拡大している点を共有。
- `withReactSSRMock` を使うテストは `__tests__/unit/hooks/useMediaQuery.test.ts` の 2 か所のみ。`vi.unmock` → `vi.doUnmock` の変更により、これまで実質機能していなかったアンモックが正しくスコープ抜け時に動くようになるが、`vi.resetModules()` を併用しているため既存テストには影響しない。
- スコープ外: `vite-tsconfig-paths` 不要警告は別 Issue で対応予定。

## おこなった動作確認

- [x] `npm run lint` … エラー・警告なし
- [x] `npm run type-check` … エラーなし
- [x] `npm run test` … 57 Test Files / 398 tests 全パス
- [x] vitest 実行ログから `canvas-mocks.ts` および `ssr-helpers.ts` の警告が消えたことを確認