### PR TITLE
【Refactor】vite-tsconfig-paths を Vite 組み込みの resolve.tsconfigPaths に置き換える

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -74,7 +74,6 @@
         "tailwindcss": "^3.4.17",
         "ts-node": "^10.9.2",
         "typescript": "^5.9.3",
-        "vite-tsconfig-paths": "^5.1.4",
         "vitest": "^4.1.8"
       }
     },
@@ -18366,27 +18365,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/tsconfck": {
-      "version": "3.1.6",
-      "resolved": "https://registry.npmjs.org/tsconfck/-/tsconfck-3.1.6.tgz",
-      "integrity": "sha512-ks6Vjr/jEw0P1gmOVwutM3B7fWxoWBL2KRDb1JfqGVawBmO5UsvmWOQFGHBPl5yxYz4eERr19E6L7NMv+Fej4w==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "tsconfck": "bin/tsconfck.js"
-      },
-      "engines": {
-        "node": "^18 || >=20"
-      },
-      "peerDependencies": {
-        "typescript": "^5.0.0"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/tsconfig-paths": {
       "version": "3.15.0",
       "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.15.0.tgz",
@@ -18949,26 +18927,6 @@
           "optional": true
         },
         "yaml": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/vite-tsconfig-paths": {
-      "version": "5.1.4",
-      "resolved": "https://registry.npmjs.org/vite-tsconfig-paths/-/vite-tsconfig-paths-5.1.4.tgz",
-      "integrity": "sha512-cYj0LRuLV2c2sMqhqhGpaO3LretdtMn/BVX4cPLanIZuwwrkVl+lK84E/miEXkCHWXuq65rhNN4rXsBcOB3S4w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "debug": "^4.1.1",
-        "globrex": "^0.1.2",
-        "tsconfck": "^3.0.3"
-      },
-      "peerDependencies": {
-        "vite": "*"
-      },
-      "peerDependenciesMeta": {
-        "vite": {
           "optional": true
         }
       }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -81,7 +81,6 @@
     "tailwindcss": "^3.4.17",
     "ts-node": "^10.9.2",
     "typescript": "^5.9.3",
-    "vite-tsconfig-paths": "^5.1.4",
     "vitest": "^4.1.8"
   }
 }

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -12,12 +12,8 @@
     "module": "esnext",
     "moduleResolution": "bundler",
     "paths": {
-      "~/*": [
-        "./src/*"
-      ],
-      "~/public/*": [
-        "./public/*"
-      ]
+      "~/*": ["./src/*"],
+      "~/public/*": ["./public/*"]
     },
     "resolveJsonModule": true,
     "types": [

--- a/frontend/vitest.config.mts
+++ b/frontend/vitest.config.mts
@@ -1,16 +1,10 @@
-import { fileURLToPath, URL } from 'node:url'
 import react from '@vitejs/plugin-react'
-import tsconfigPaths from 'vite-tsconfig-paths'
 import { defineConfig } from 'vitest/config'
 
 export default defineConfig({
-  plugins: [react(), tsconfigPaths()],
+  plugins: [react()],
   resolve: {
-    alias: [
-      { find: /^~\/public\//, replacement: fileURLToPath(new URL('./public/', import.meta.url)) },
-      { find: /^~\//, replacement: fileURLToPath(new URL('./src/', import.meta.url)) },
-      { find: /^~$/, replacement: fileURLToPath(new URL('./src', import.meta.url)) },
-    ],
+    tsconfigPaths: true,
   },
   test: {
     globals: true,


### PR DESCRIPTION
# 概要

Closes #184 

Vite 8 が tsconfig paths 解決を組み込みでサポートするようになり、`vite-tsconfig-paths` プラグインが不要になった。プラグインを削除し、`resolve.tsconfigPaths: true` に置き換える。

# 概要

Vite 8 が tsconfig paths 解決を組み込みでサポートするようになり、`vite-tsconfig-paths` プラグインが不要になった。プラグインを削除し、`resolve.tsconfigPaths: true` に置き換える。

## 細かな変更点

### vitest.config.mts

- `vite-tsconfig-paths` の import を削除
- `node:url` の import を削除（`fileURLToPath` / `URL` が不要になったため）
- `plugins` 配列から `tsconfigPaths()` を削除
- `resolve.alias` の3要素を削除し、`resolve.tsconfigPaths: true` に置き換え

### package.json

- `vite-tsconfig-paths` を `devDependencies` から削除（`npm uninstall` で対応）

## 影響範囲・懸念点

- `vitest.config.mts` の `resolve.alias` に定義していた3要素（`~/public/`, `~/`, `~`）はすべて tsconfig.json の `paths` で等価に解決される
  - `~`（裸の `~`）の使用箇所が無いことを `grep -rn "from '~'" src/ __tests__/` で確認済み
- `tsconfig.json` 側に変更はなく、既存の `paths` 設定がそのまま使われる
- スコープ外: tsconfig.json の `baseUrl` 非推奨警告は別 Issue で対応予定

## おこなった動作確認

- [x] `npm run lint` … エラー・警告なし
- [x] `npm run type-check` … エラーなし
- [x] `npm run test` … 57 Test Files / 398 tests 全パス
- [x] vitest 実行ログから `vite-tsconfig-paths` 関連の警告（4回出力されていた）が消えたことを確認