### PR TITLE
【Refactor】tsconfig.json の baseUrl オプションを削除

### DIFF
--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -8,12 +8,12 @@
       "dom.iterable",
       "esnext"
     ],
-    "baseUrl": ".",
     "module": "esnext",
     "moduleResolution": "bundler",
     "paths": {
       "~/*": ["./src/*"],
-      "~/public/*": ["./public/*"]
+      "~/public/*": ["./public/*"],
+      "__tests__/*": ["./__tests__/*"]
     },
     "resolveJsonModule": true,
     "types": [


### PR DESCRIPTION
# 概要

Closes #186 

TypeScript 7.0 で動作しなくなることが明記された `baseUrl` オプションを `tsconfig.json` から削除する。
あわせて、`baseUrl` に依存していた `__tests__/*` の絶対パス import を維持するため、`paths` に `__tests__/*` の定義を追加する。

## 細かな変更点

### tsconfig.json

- `"baseUrl": "."` を削除
- `paths` に `"__tests__/*": ["./__tests__/*"]` を追加

## 影響範囲・懸念点

### `paths` 追加の理由

- 当初の対応方針では `baseUrl` 削除のみを想定していたが、`type-check` 実行時に `__tests__/...` で始まる絶対パス import を解決できないエラーが 9ファイル・16箇所で発生した。
- これらの import は `baseUrl: "."` 配下の暗黙解決で動いていたものであり、`baseUrl` 削除後は `paths` に明示する必要がある。`paths` に `__tests__/*` を追加することで対応した。

### 影響範囲

- `~/*` / `~/public/*` の挙動には影響なし
- `vitest.config.mts` 側は `resolve.tsconfigPaths: true`（#184 で設定済み）が tsconfig.json の `paths` を自動で読むため、追加設定不要
- Next.js のビルドは `src/` 配下しかバンドルしないため、`__tests__/*` の `paths` 定義はビルド成果物に影響しない

## おこなった動作確認

- [x] `npm run lint` … エラー・警告なし
- [x] `npm run type-check` … エラーなし（`baseUrl` 非推奨警告も消滅）
- [x] `npm run test` … 57 Test Files / 398 tests 全パス
- [x] `npm run build` … 成功（14 ページ生成、ビルド時間 62 秒）
- [x] エディタで `tsconfig.json` を開いても `baseUrl` 関連の警告が表示されないことを確認

## その他

`paths` 追加が当初の Issue 本文に書かれていなかった作業のため、レビュー時に背景を確認いただけると助かります。